### PR TITLE
chore: add dependabot for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # TypeScript 7 breaks tsup dts (rollup-plugin-dts peers stop at ^6)
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Add `.github/dependabot.yml` with weekly updates for `npm` and `github-actions`, ignoring typescript major bumps until tsup supports TypeScript 7.

Closes #19