### PR TITLE
chore: use actionsforge node-ci and tag-and-release reusables

### DIFF
--- a/.github/workflows/build-and-tag.yml
+++ b/.github/workflows/build-and-tag.yml
@@ -12,76 +12,11 @@ permissions:
 
 jobs:
   build-and-release:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '20'
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build Action
-        run: npm run build
-
-      - name: Commit built files
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add dist/
-          git commit -m "chore: auto-compile action" || echo "No changes to commit"
-          git push
-
-      - name: Tag and release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git fetch --tags
-
-          latest_tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-
-          if [[ "$latest_tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-            major="${BASH_REMATCH[1]}"
-            minor="${BASH_REMATCH[2]}"
-            patch="${BASH_REMATCH[3]}"
-
-            if (( patch < 99 )); then
-              patch=$((patch + 1))
-            else
-              patch=0
-              if (( minor < 99 )); then
-                minor=$((minor + 1))
-              else
-                minor=0
-                major=$((major + 1))
-              fi
-            fi
-          else
-            major=1
-            minor=0
-            patch=0
-          fi
-
-          new_tag="v${major}.${minor}.${patch}"
-          echo "New tag: $new_tag"
-
-          # Generate changelog
-          if [ -n "$latest_tag" ]; then
-            git log "$latest_tag"..HEAD --pretty=format:"- %s" > changelog.txt
-          else
-            git log --pretty=format:"- %s" > changelog.txt
-          fi
-
-          git tag "$new_tag"
-          git push origin "$new_tag"
-
-          git tag -f "v$major" "$new_tag"
-          git push -f origin "v$major"
-
-          gh release create "$new_tag" --title "$new_tag" --notes-file changelog.txt
+    uses: actionsforge/actions/.github/workflows/node-action-tag-and-release.yml@main
+    with:
+      node-version: '20'
+      build: true
+      commit-dist: true
+      create-release: true
+      update-major-tag: true
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,43 +8,13 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: dummy-token
-      GITHUB_REPOSITORY: example-org/example-repo
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Type check
-        run: npm run build
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Security audit
-        run: npm audit || true
-
-      - name: Run unit tests
-        run: npm test
-
-      - name: Test coverage
-        run: npm test -- --coverage
-
-      - name: Verify build
-        run: |
-          npm run build
-          test -f dist/index.js
-          test -f dist/configure-environment.sh
-
-      - name: Check dependencies
-        run: npm outdated || true
+    permissions:
+      contents: read
+    uses: actionsforge/actions/.github/workflows/node-ci-workflow.yml@main
+    with:
+      node-version: '20'
+      typecheck: true
+      coverage: true
+      build: true
+      # Soft-fail audit lived in the old workflow (npm audit || true)
+      audit: false


### PR DESCRIPTION
## Summary
- `ci.yml` → `node-ci-workflow` (Node 20, typecheck, coverage, build; audit off)
- `build-and-tag.yml` → `node-action-tag-and-release` with `commit-dist: true`
- Leave `test-action.yml` local (YAML fixtures + `GH_ENV_CONFIG_TOKEN`)

## Test plan
- [ ] CI green on this PR
- [ ] After merge, next main push tags via reusable